### PR TITLE
remove unneeded `intllib`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,19 +7,6 @@
 biome_lib = {}
 biome_lib.modpath = minetest.get_modpath("biome_lib")
 
--- Boilerplate to support localized strings if intllib mod is installed.
-local S
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		S = intllib.make_gettext_pair()
-	else
-		S = intllib.Getter()
-	end
-else
-	S = function(s) return s end
-end
-biome_lib.intllib = S
-
 local c1 = minetest.settings:get("biome_lib_default_grow_through_nodes")
 biome_lib.default_grow_through_nodes = {["air"] = true}
 if c1 then

--- a/locale/de.txt
+++ b/locale/de.txt
@@ -1,5 +1,0 @@
-# Translation by Xanthin
-
-someone = jemand
-Sorry, %s owns that spot. = Entschuldige, %s gehoert diese Stelle.
-[Plantlife Library] Loaded = [Plantlife Library] Geladen

--- a/locale/fr.txt
+++ b/locale/fr.txt
@@ -1,5 +1,0 @@
-# Template
-
-someone = quelqu'un
-Sorry, %s owns that spot. = Désolé, %s possède cet endroit.
-[Plantlife Library] Loaded = [Librairie Plantlife] Chargée.

--- a/locale/ru.txt
+++ b/locale/ru.txt
@@ -1,5 +1,0 @@
-# Translation by inpos
-
-someone = кто-то 
-Sorry, %s owns that spot. = Извините, но %s уже является владельцем этой точки.
-[Plantlife Library] Loaded = [Plantlife Library] Загружена

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -1,5 +1,0 @@
-# Template
-
-someone = 
-Sorry, %s owns that spot. = 
-[Plantlife Library] Loaded = 

--- a/locale/tr.txt
+++ b/locale/tr.txt
@@ -1,5 +1,0 @@
-# Turkish translation by mahmutelmas06
-
-someone = birisi
-Sorry, %s owns that spot. = Üzgünüm, buranın sahibi %s.
-[Plantlife Library] Loaded = [Plantlife Library] yüklendi

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = biome_lib
 min_minetest_version = 5.2.0
-optional_depends = default, intllib
+optional_depends = default


### PR DESCRIPTION
This PR removes the dependency to `intllib`
This mod does not use translations:
```
biome_lib$ grep  '\<S(' $(find -name \*.lua) || echo nix
nix
```