### PR TITLE
biome_lib.register_on_generate: Adding `density` field

### DIFF
--- a/API.txt
+++ b/API.txt
@@ -26,7 +26,7 @@ biome_lib.register_active_spawner(sdelay, splant, sradius, schance, ssurface, sa
 
 This first function is an ABM-based spawner function originally created as
 part of Ironzorg's flowers mod.  It has since been largely extended and
-expanded.  There are two ways to call this function:  You can either pass it 
+expanded.  There are two ways to call this function:  You can either pass it
 several individual string and number parameters to use the legacy interface,
 or you can pass a single biome definition as a table, with all of your options
 spelled out nicely.  This is the preferred method.
@@ -135,7 +135,7 @@ biome = {
 						-- radius.  Defaults to 1 but is ignored if near_nodes
 						-- isn't set.  Bear in mind that the total area to be
 						-- checked is equal to:
-						-- (near_nodes_size^2)*near_nodes_vertical*2 
+						-- (near_nodes_size^2)*near_nodes_vertical*2
 						-- For example, if size is 10 and vertical is 4, then
 						-- the area is (10^2)*8 = 800 nodes in size, so you'll
 						-- want to make sure you specify a value appropriate
@@ -202,7 +202,7 @@ biome = {
 }
 
 [*] spawn_plants must be either a table or a string.  If it's a table, the
-values therein are treated as a list of nodenames to pick from randomly on 
+values therein are treated as a list of nodenames to pick from randomly on
 each application of the ABM code. The more nodes you can pack into this
 parameter to avoid making too many calls to this function, the lower the CPU
 load will likely be.
@@ -225,7 +225,7 @@ call this function with two parameters:  a table with your object's biome
 information, and a string, function, or table describing what to do if the
 engine finds a suitable surface node (see below).
 
-The biome table contains quite a number of options, though there are fewer 
+The biome table contains quite a number of options, though there are fewer
 here than are available in the ABM-based spawner, as some stuff doesn't make
 sense at map-generation time.
 
@@ -256,6 +256,10 @@ biome = {
 						-- (80x80x80 nodes).  Defaults to 5, but be sure you
 						-- set this to some reasonable value depending on your
 						-- object and its size if 5 is insufficient.
+	density = num,		-- An alternative to setting rarity and max_count,
+						-- this is simply a percentage of the eligible nodes
+						-- you want objects to be generated on. If set, then
+						-- rarity and max_count will be ignored.
 	seed_diff = num,	-- Perlin seed-diff value.  Defaults to 0, which
 						-- causes the function to inherit the global value of
 						-- 329.
@@ -341,7 +345,7 @@ definition table as the only parameter.  These are defined like so:
 
 options = {
 	label = string,		-- set this to identify the ABM for Minetest's
-						-- profiler.  If not set, biome_lib will set it to 
+						-- profiler.  If not set, biome_lib will set it to
 						-- "biome_lib.update_plant(): " appended with the node
 						-- in grow_plant (or the first item if it's a table)
 	grow_plant = "string" or {table}, -- Name(s) of the node(s) to be grown
@@ -406,7 +410,7 @@ If this value is set to a simple string, this is treated as the name of the
 function to use to grow the plant.  In this case, all of the usual growing
 code is executeed, but then instead of a plant being simply added to the
 world, grow_result is ignored and the named function is executed and passed a
-few parmeters in the following general form: 
+few parmeters in the following general form:
 
 	somefunction(pos, perlin1, perlin2)
 
@@ -431,7 +435,7 @@ search around the given position for a neighboring wall, returning the first
 one it finds as a facedir value, or nil if there are no adjacent walls.
 
 If randomflag is set to true, the function will just return the facedir of any
-random wall it finds adjacent to the target position.  Defaults to false if 
+random wall it finds adjacent to the target position.  Defaults to false if
 not specified.
 
 =====
@@ -463,7 +467,7 @@ spammy stuff.
 biome_lib.generate_ltree(pos, treemodel)
 biome_lib.grow_ltree(pos, treemodel)
 
-In the case of the growing code and the mapgen-based tree generator code, 
+In the case of the growing code and the mapgen-based tree generator code,
 generating a tree is done via the above two calls, which in turn immediately
 call the usual spawn_tree() functions.  This rerouting exists as a way for
 other mods to hook into biome_lib's tree-growing functions in general,
@@ -475,7 +479,7 @@ is to be placed.  'treemodel' is the standard L-Systems tree definition table
 expected by the spawn_tree() function.  Refer to the 'trunk' field in that
 table to derive the name of the tree being spawned.
 
-biome_lib.grow_ltree(pos, treemodel) does the same sort of thing whenever a 
+biome_lib.grow_ltree(pos, treemodel) does the same sort of thing whenever a
 tree is spawned within the abm-based growing code, for example when growing a
 sapling into a tree.
 
@@ -518,7 +522,7 @@ appears to be the standard now.  Those values are:
 	temperature_persistence = 0.5
 	temperature_scale = 150
 
-The way Perlin values are used by this mod, in keeping with the snow mod's 
+The way Perlin values are used by this mod, in keeping with the snow mod's
 apparent methods, larger values returned by the Perlin function represent
 *colder* temperatures.  In this mod, the following table gives a rough
 approximation of how temperature maps to these values, normalized to
@@ -542,7 +546,7 @@ Perlin		Approx. Temperature
 
 Included in this table are even 0.25 steps in Perlin values along with some
 common temperatures on both the Centigrade and Fahrenheit scales.  Note that
-unless you're trying to model the Moon or perhaps Mercury in your mods/maps, 
+unless you're trying to model the Moon or perhaps Mercury in your mods/maps,
 you probably won't need to bother with Perlin values of less than -0.56 or so.
 
 


### PR DESCRIPTION
Adding `density` field which provides a different method of specifying the density of the spawning. If set, `max_count` and `rarity` are ignored.

`max_count` and `rarity` has the following issues.
1. We can't have less than one object per node-block
2. The number of objects per node-block isn't proportional to the number of eligible spawning nodes, this means in areas with fewer eligible spawning nodes there is a greater concentration of objects in each eligible location.

For backwards compatibility I thought it better to provide an alternative method, and leave `max_count` and `rarity` alone.

`density` is simply a percentage of the available nodes that spawning will be attempted on. This is calculated by taking the number of eligible nodes, and multiplying by (density / 100). If this results in a number of nodes that isn't a whole number, e.g. 3.7, then this will be randomly either rounded up or down. The chance of rounding up is proportional to how close it is to the ceiling, so for 3.7 it will be rounded up to 4 70% of the time. This allows very low densities to be specified that will actually be accurate, and not inaccurate due to rounding.